### PR TITLE
Plugin vs Id in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-apply id: 'java'
+apply plugin: 'java'
 
 /*
 This builds the Idea gradle plugin. This requires a copy of Idea 9 to be installed on your machine as well as at least Gradle.


### PR DESCRIPTION
I'm fairly new to gradle, but I seem to have found an error in the build script.
When I tried to run the build as described on the git repo wiki, I got an error on line 1.
Changing this line from apply id to apply plugin seems to fix the problem, and gradle plugin now works fine in idea 10.

Thanks again for the great work :)

regards, 
Ken
